### PR TITLE
Remove unused imports

### DIFF
--- a/Sources/CGOperators.swift
+++ b/Sources/CGOperators.swift
@@ -4,7 +4,6 @@
  *  Licensed under the MIT license. See LICENSE file.
  */
 
-import Foundation
 import CoreGraphics
 
 /// Protocol used to describe a type as a Core Graphics 2D vector

--- a/Tests/CGOperatorsTests/CGOperatorsTests.swift
+++ b/Tests/CGOperatorsTests/CGOperatorsTests.swift
@@ -4,7 +4,6 @@
  *  Licensed under the MIT license. See LICENSE file.
  */
 
-import Foundation
 import CoreGraphics
 import XCTest
 import CGOperators


### PR DESCRIPTION
Hey, great framework.
This PR removes `Foundation` imports. **CGOperators** don't need them to work.